### PR TITLE
Guarantee clean

### DIFF
--- a/project_installer.sh
+++ b/project_installer.sh
@@ -21,6 +21,9 @@ if [[ "$NODEJS_CURRENT_VERSION" != "$NODEJS_TARGET_VERSION" ]]; then
   asdf reshim nodejs;
 fi
 
+rm -Rf ./node_modules
+rm ./*.lock
+
 installNpmModuleIfNeeded "@angular/cli" "package.json" "ng -v";
 installNpmModuleIfNeeded "typescript" "package.json" "ng -v";
 installNpmModuleIfNeeded "tslint" "package.json" "tslint -v" "true";


### PR DESCRIPTION
Despite rebuilding and supposedly relinking all the packages properly, node doesn't always provide a working state.  Removing and rebuilding clean from the package.json does reliably work.  Currently when used on a system that already has installed once already, running the script takes roughly 25sec, which is an acceptable cost for reliability.