### PR TITLE
Clarification of asdf requiring a shell restart added

### DIFF
--- a/WindowsReadme.md
+++ b/WindowsReadme.md
@@ -8,6 +8,8 @@ click [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to inst
 
 - Run the install scripts on whichever repo you are on. Should work if running through wsl.
   - If not update this document so future Windows users have an easier time!
+- After running install_prerequisites follow the node setup instructions: [node setup](https://github.com/bcgov/eagle-dev-guides/blob/master/dev_guides/node_npm_requirements.md) before running setup project.
+
 
 ### Known Issues
 
@@ -22,6 +24,7 @@ click [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to inst
 
 - Couldn't use asdf to install java openjdk 11 so just apt-install
 - Needed unzip to install gradle using asdf so make sure to install that 
+- If asdf did not install correctly follow manual process at:  [asdf](https://asdf-vm.com/#/core-manage-asdf-vm)
 
 ### If not using wsl
 

--- a/dev_guides/node_npm_requirements.md
+++ b/dev_guides/node_npm_requirements.md
@@ -9,6 +9,8 @@ Run the utility file at the root of this repo called 'developer_install_prerequi
 ```
 
 This will take care of installing the basic tools and prerequisites needed for EAO EPIC Eagle
+- Make sure to restart your shell before continuing then verify asdf installed
+- If it did not install follow manual install instructions at [WindowsReadme.md](https://github.com/bcgov/eagle-dev-guides/blob/master/WindowsReadme.md})
 
 ```
 asdf install nodejs x.xx.x


### PR DESCRIPTION
Updated instructions when install on wsl to include instructions to restart your shell after installing asdf. Also updated node instructions for similar information.